### PR TITLE
perf: pass file handle instead of name for IO

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -1,17 +1,19 @@
 function initialize_trajectory!(filename, params::RotationParameters, scheduler)
-    jldopen(filename, "w") do f
-        JLD2.Group(f, "TimeSteps")
-        m = JLD2.Group(f, "Params")
-        m["walkers"] = params.walkers
-        m["H"] = params.H
-        m["rate"] = params.rate
-        m["tᵪ"] = params.tᵪ
-        m["tₑ"] = params.tₑ
-        m["dt"] = params.dt
-        m["T"] = params.T
-        m["scheduler"] = scheduler
-    end
+    file_handle = jldopen(filename, "w")
 
+    JLD2.Group(file_handle, "TimeSteps")
+
+    m = JLD2.Group(file_handle, "Params")
+    m["walkers"] = params.walkers
+    m["H"] = params.H
+    m["rate"] = params.rate
+    m["tᵪ"] = params.tᵪ
+    m["tₑ"] = params.tₑ
+    m["dt"] = params.dt
+    m["T"] = params.T
+    m["scheduler"] = scheduler
+
+    return file_handle
 end
 
 function get_length_simulation(filename)
@@ -25,12 +27,10 @@ function get_time_trajectory(filename)
     return collect(dt:dt:N*dt)
 end
 
-function save_timestep!(filename::String, M::Vector{<:AbstractMatrix}, time, scheduler)
+function save_timestep!(file_handle::JLD2.JLDFile{JLD2.MmapIO}, M::Vector{<:AbstractMatrix}, time, scheduler)
     if (time ∈ scheduler) || (time == 0)
         v = [prod(euler_from_rotation(m)) for m in M]
-        jldopen(filename, "a") do f
-            f["TimeSteps/$(time)"] = v
-        end
+        file_handle["TimeSteps/$(time)"] = v
     end
 end
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -10,26 +10,29 @@ end
 function simulation(params::RotationParameters; path::String="./", rng=Xoshiro(), scheduler=1)
     mkpath(path)
     trajectory_file = joinpath(path, "traj.jld2")
-    
+
     N = round(Int, params.T / params.dt)
     scheduler = set_scheduler(scheduler, N)
     R = [SMatrix{3,3,Float64}(I) for _ in 1:params.walkers]
     Rₜ = [SMatrix{3,3,Float64}(I) for _ in 1:params.walkers]
     dR = [SMatrix{3,3,Float64}(I) for _ in 1:params.walkers]
-    i = 1
-    initialize_trajectory!(trajectory_file, params, scheduler)
-    save_timestep!(trajectory_file, R, 0, scheduler)
+
+    file_handle = initialize_trajectory!(trajectory_file, params, scheduler)
+    save_timestep!(file_handle, R, 0, scheduler)
+
     if params.simulation == "Escape"
         sample_exponential!(params; rng=rng)
     end
+
     prog = Progress(params.walkers; desc="Simulating walkers...")
+    i = 1
     while i < N+1
 
         dΩ = sqrt(params.dt * params.Dᵣ) *randn(rng, Float64, (3, params.walkers))
         for walker in 1:params.walkers
             if i * params.dt < params.tᵪ[walker]
                 dR[walker] = cage(Rₜ[walker], dΩ[:, walker], params.H)
-            elseif i * params.dt < params.tₑ[walker] 
+            elseif i * params.dt < params.tₑ[walker]
                 if params.simulation == "Escape"
                     dR[walker] = rotation_matrix_from_omega(dΩ[:, walker] ./ (5 * sqrt(params.dt)))
                 else
@@ -42,11 +45,13 @@ function simulation(params::RotationParameters; path::String="./", rng=Xoshiro()
             end
             R[walker] = R[walker] * dR[walker]
             Rₜ[walker] = Rₜ[walker] * dR[walker]
-            
+
         end
-        save_timestep!(trajectory_file, R, i, scheduler)
+        save_timestep!(file_handle, R, i, scheduler)
         i += 1
         next!(prog)
     end
+
+    close(file_handle)
     return nothing
 end


### PR DESCRIPTION
**Summary**
This PR changes the API to write trajectories to file.
Instead of passing the file path, the function now expects a file handle. This removes the need to open/close the file at each write operation, which was a huge performance bottleneck.

The function that creates the file structure now returns a file handle to the opened file, which is meant to be passed to the write function.

**Test plan**
Speedup is hard to quantify, as the timing was scaling non linearly with the number of steps or walkers in the past implementation. But 1-2 orders of magnitude have been observed.

**Notes**
This PR doesn't change the read API, as it's unclear to me at the time if performance is also an issue there